### PR TITLE
update to use tsc with globby@7

### DIFF
--- a/check-js-types.js
+++ b/check-js-types.js
@@ -48,4 +48,10 @@ const args = [].concat(
     filesList
 )
 
+// FUTURE TODO: put this into a more descriptive try/catch block
+// and add testing to ensure this works properly
+console.log('check for valid tsc (TypeScript compiler) version')
+execa.sync('tsc', '--version', { stdio: 'inherit' })
+console.log('valid tsc version found')
+
 execa.sync('tsc', args, { stdio: 'inherit' })

--- a/check-js-types.js
+++ b/check-js-types.js
@@ -2,6 +2,8 @@
 
 const meow = require('meow')
 
+const globby = require('globby')
+
 const execa = require('execa')
 
 const cli = meow(`
@@ -30,6 +32,10 @@ if (files.length === 0) {
 
 console.info(`files: ${files}`)
 
+const filesList = globby.sync(files)
+
+console.info(`files, expanded using globby: ${filesList}`)
+
 const flags = cli.flags
 
 console.info(`flags: ${JSON.stringify(flags)}`)
@@ -39,8 +45,7 @@ const args = [].concat(
     '--checkJs',
     '--noEmit',
     c.flags.strict ? '--strict' : [],
-    '-g',
-    c.input[0]
+    filesList
 )
 
-execa.sync('glob-tsc', args, { stdio: 'inherit' })
+execa.sync('tsc', args, { stdio: 'inherit' })

--- a/check-js-types.js
+++ b/check-js-types.js
@@ -22,8 +22,6 @@ const cli = meow(`
     }
 })
 
-const c = cli;
-
 const files = cli.input
 
 if (files.length === 0) {
@@ -44,7 +42,7 @@ const args = [].concat(
     '--allowJs',
     '--checkJs',
     '--noEmit',
-    c.flags.strict ? '--strict' : [],
+    flags.strict ? '--strict' : [],
     filesList
 )
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "execa": "^3.2.0",
-    "glob-tsc": "^0.0.1",
+    "globby": "^7.1.1",
     "meow": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
instead of `glob-tsc`

output seems to be cleaner with this update

P.S. globby@7 seems to have better luck than globby@10 with backslash on Windows

/cc @rbiggs