### PR TITLE
log tsc arguments

### DIFF
--- a/check-js-types.js
+++ b/check-js-types.js
@@ -52,4 +52,6 @@ console.log('check for valid tsc (TypeScript compiler) version')
 execa.sync('tsc', ['--version'], { stdio: 'inherit' })
 console.log('valid tsc version found')
 
+console.info(`run tsc with arguments: ${args.join(' ')}`)
+
 execa.sync('tsc', args, { stdio: 'inherit' })


### PR DESCRIPTION
rationale: this is a quick way to check that the JavaScript computes the correct set of arguments for the `tsc` call